### PR TITLE
[feat] 전체 뉴스 조회 api 생성

### DIFF
--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/ArticleFailureCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/ArticleFailureCode.java
@@ -1,0 +1,18 @@
+package com.newsnack.www.newsnackserver.common.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ArticleFailureCode implements FailureCode{
+
+    /**
+     * 400 BAD REQUEST
+     */
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/success/ArticleSuccessCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/success/ArticleSuccessCode.java
@@ -1,0 +1,19 @@
+package com.newsnack.www.newsnackserver.common.code.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ArticleSuccessCode implements SuccessCode{
+
+    /**
+     * 200 OK
+     **/
+    GET_ARTICLES_SUCCESS(HttpStatus.OK, "기사 조회에 성공했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/controller/ArticleController.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/controller/ArticleController.java
@@ -1,0 +1,37 @@
+package com.newsnack.www.newsnackserver.controller;
+
+import com.newsnack.www.newsnackserver.dto.response.ArticleResponse;
+import com.newsnack.www.newsnackserver.service.ArticleService;
+import com.newsnack.www.newsnackserver.common.code.failure.ArticleFailureCode;
+import com.newsnack.www.newsnackserver.common.code.success.ArticleSuccessCode;
+import com.newsnack.www.newsnackserver.common.exception.NewSnackException;
+import com.newsnack.www.newsnackserver.common.response.NewSnackResponse;
+import com.newsnack.www.newsnackserver.domain.article.model.LocationCategory;
+import com.newsnack.www.newsnackserver.domain.article.model.SearchOrder;
+import com.newsnack.www.newsnackserver.domain.article.model.SectionCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/articles")
+@RequiredArgsConstructor
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @GetMapping
+    public NewSnackResponse<List<ArticleResponse>> getArticles(@RequestParam SearchOrder order,
+                                                               @RequestParam("page")Integer page,
+                                                               @RequestParam(required = false)SectionCategory sectionCategory,
+                                                               @RequestParam(required = false)LocationCategory locationCategory) {
+        if (order == null || page < 0 || (sectionCategory != null && locationCategory != null) ) {
+            throw new NewSnackException(ArticleFailureCode.INVALID_PARAMETER);
+        }
+        return NewSnackResponse.success(ArticleSuccessCode.GET_ARTICLES_SUCCESS, articleService.getArticles(order, sectionCategory, locationCategory, page));
+    }
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/Article.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/Article.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Getter
@@ -28,4 +29,7 @@ public class Article extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private LocationCategory locationCategory;
+
+    @Formula("(select count(*) from article_heart where article_heart.article_id = id)")
+    private int heartCount;
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/SearchOrder.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/SearchOrder.java
@@ -1,0 +1,13 @@
+package com.newsnack.www.newsnackserver.domain.article.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SearchOrder {
+
+    RECENT("recent"), POPULAR("popular");
+
+    private final String value;
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleJpaRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleJpaRepository.java
@@ -1,7 +1,28 @@
 package com.newsnack.www.newsnackserver.domain.article.repository;
 
 import com.newsnack.www.newsnackserver.domain.article.model.Article;
+import com.newsnack.www.newsnackserver.domain.article.model.LocationCategory;
+import com.newsnack.www.newsnackserver.domain.article.model.SectionCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleJpaRepository extends JpaRepository<Article, Long> {
+
+    @Query("SELECT a from Article a order by a.id desc")
+    Page<Article> findAllOrderByIdDesc(Pageable pageable);
+    Page<Article> findAllBySectionCategoryOrderByIdDesc(SectionCategory sectionCategory, Pageable pageable);
+
+    Page<Article> findAllByLocationCategoryOrderByIdDesc(LocationCategory locationCategory, Pageable pageable);
+
+    @Query("SELECT a from Article a order by a.heartCount desc, a.id desc")
+    Page<Article> findAllOrderByPopularAndIdDesc(Pageable pageable);
+
+    @Query("SELECT a from Article a where a.sectionCategory = :sectionCategory order by a.heartCount desc, a.id desc")
+    Page<Article> findAllBySectionCategoryOrderByHeartCountDescAndIdDesc(SectionCategory sectionCategory, Pageable pageable);
+
+    @Query("SELECT a from Article a where a.locationCategory = :locationCategory order by a.heartCount desc, a.id desc")
+    Page<Article> findAllByLocationCategoryOrderByHeartCountDescAndIdDesc(LocationCategory locationCategory, Pageable pageable);
+
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleRepository.java
@@ -1,0 +1,4 @@
+package com.newsnack.www.newsnackserver.domain.article.repository;
+
+public interface ArticleRepository extends ArticleJpaRepository {
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/commom/BaseTimeEntity.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/commom/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package com.newsnack.www.newsnackserver.domain.commom;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/response/ArticleResponse.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/response/ArticleResponse.java
@@ -1,0 +1,13 @@
+package com.newsnack.www.newsnackserver.dto.response;
+
+import com.newsnack.www.newsnackserver.domain.article.model.Article;
+import com.newsnack.www.newsnackserver.domain.article.model.LocationCategory;
+import com.newsnack.www.newsnackserver.domain.article.model.SectionCategory;
+
+import java.time.LocalDateTime;
+
+public record ArticleResponse(Long id, String title, String imageUrl, LocalDateTime createdAt, SectionCategory sectionCategory, LocationCategory locationCategory) {
+    public static ArticleResponse of (Article article) {
+        return new ArticleResponse(article.getId(), article.getTitle(), article.getImageUrl(), article.getCreatedAt(), article.getSectionCategory(), article.getLocationCategory());
+    }
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/service/ArticleService.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/service/ArticleService.java
@@ -1,0 +1,47 @@
+package com.newsnack.www.newsnackserver.service;
+
+import com.newsnack.www.newsnackserver.dto.response.ArticleResponse;
+import com.newsnack.www.newsnackserver.domain.article.model.LocationCategory;
+import com.newsnack.www.newsnackserver.domain.article.model.SearchOrder;
+import com.newsnack.www.newsnackserver.domain.article.model.SectionCategory;
+import com.newsnack.www.newsnackserver.domain.article.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArticleService {
+    private final static int PAGE_SIZE = 9;
+    private final ArticleRepository articleRepository;
+
+    public List<ArticleResponse> getArticles(SearchOrder order, SectionCategory sectionCategory, LocationCategory locationCategory, Integer page) {
+
+        if(order.equals(SearchOrder.RECENT)) {
+            if (sectionCategory != null) {
+                return articleRepository.findAllBySectionCategoryOrderByIdDesc(sectionCategory, PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+            }
+            if (locationCategory != null) {
+                return articleRepository.findAllByLocationCategoryOrderByIdDesc(locationCategory, PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+            }
+           return articleRepository.findAllOrderByIdDesc(PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+        }
+       if(order.equals(SearchOrder.POPULAR)) {
+           if (sectionCategory != null) {
+               return articleRepository.findAllBySectionCategoryOrderByHeartCountDescAndIdDesc(sectionCategory, PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+           }
+           if (locationCategory != null) {
+               return articleRepository.findAllByLocationCategoryOrderByHeartCountDescAndIdDesc(locationCategory, PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+           }
+            return articleRepository.findAllOrderByPopularAndIdDesc(PageRequest.of(page, PAGE_SIZE)).getContent().stream().map(ArticleResponse::of).collect(Collectors.toList());
+        } else {
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #13 

## Description ✔️
- 전체 뉴스 조회 api 생성
- 최신순, 좋아요순 정렬
- 카테고리별 필터링
- 페이징 적용

## To Reviewers
