### PR TITLE
[refactor] 뉴스 단건 조회 로직 변경

### DIFF
--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/Article.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/model/Article.java
@@ -1,10 +1,14 @@
 package com.newsnack.www.newsnackserver.domain.article.model;
 
+import com.newsnack.www.newsnackserver.domain.articleheart.model.ArticleHeart;
 import com.newsnack.www.newsnackserver.domain.commom.BaseTimeEntity;
+import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,6 +33,9 @@ public class Article extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private LocationCategory locationCategory;
 
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ArticleHeart> articleHearts;
+
     private int heartCount;
 
     public void increaseHeartCount() {
@@ -37,5 +44,13 @@ public class Article extends BaseTimeEntity {
 
     public void decreaseHeartCount() {
         this.heartCount--;
+    }
+
+    public boolean isLikedByMember(Member member) {
+        for (ArticleHeart articleHeart : articleHearts) {
+            if (articleHeart.getMember() == member)//동일한 transaction 내 같은 식별자 갖는 프록시는 == 동일 보장.
+                return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/article/repository/ArticleRepository.java
@@ -1,4 +1,11 @@
 package com.newsnack.www.newsnackserver.domain.article.repository;
 
+import com.newsnack.www.newsnackserver.domain.article.model.Article;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
 public interface ArticleRepository extends ArticleJpaRepository {
+    @Query("select distinct a from Article a left join fetch a.articleHearts where a.id = :id")
+    Optional<Article> findArticleWithArticleHeartsByIdJPQL(Long id);
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/articleheart/repository/ArticleHeartJpaRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/articleheart/repository/ArticleHeartJpaRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ArticleHeartJpaRepository extends JpaRepository<ArticleHeart, Long> {
-    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
     Optional<ArticleHeart> findByArticleAndMember(Article article, Member member);
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/service/ArticleService.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/service/ArticleService.java
@@ -57,14 +57,15 @@ public class ArticleService {
         }
     }
 
-    public ArticleIndividualResponse getArticle(Long articleId, Long memberId) {//현재 로그인 x 기준임
-        Article article = articleRepository.findById(articleId).orElseThrow(() -> new ArticleException(ArticleFailureCode.ARTICLE_NOT_FOUND));
+    public ArticleIndividualResponse getArticle(Long articleId, Long memberId) {
         if (memberId == null) {
+            Article article = articleRepository.findById(articleId).orElseThrow(() -> new ArticleException(ArticleFailureCode.ARTICLE_NOT_FOUND));
             boolean isLiked = false;
             return ArticleIndividualResponse.of(article, isLiked);
         }
-        boolean isLiked = articleHeartJpaRepository.existsByArticleIdAndMemberId(articleId, memberId);
-        return ArticleIndividualResponse.of(article, isLiked);
+        Article article = articleRepository.findArticleWithArticleHeartsByIdJPQL(articleId).orElseThrow(() -> new ArticleException(ArticleFailureCode.ARTICLE_NOT_FOUND));
+        Member member = memberJpaRepository.getReferenceById(memberId);//Id만 필요하니까 프록시로 받음
+        return ArticleIndividualResponse.of(article, article.isLikedByMember(member));
     }
 
     public List<ArticleMainPageResponse> getMainArticles() {


### PR DESCRIPTION
## Related Issue 📌
- close #25 

## Description ✔️
- 뉴스 좋아요 여부를 위해 쿼리를 보내는 것 제거하기 위해 뉴스 조회시 중간테이블도 조인해서 가져온 후 어플리케이션 단에서 좋아요 여부 확인하도록 변경

## To Reviewers
