### PR TITLE
[feat] 토론 투표, 토론 댓글 관련 api 생성

### DIFF
--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateFailureCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateFailureCode.java
@@ -11,7 +11,12 @@ public enum DebateFailureCode implements FailureCode {
     /**
      * 404 Not Found
      */
-    DEBATE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 토론입니다.");
+    DEBATE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 토론입니다."),
+
+    /**
+     * 409 Conflict
+     */
+    ALREADY_VOTED_DEBATE(HttpStatus.NOT_FOUND, "이미 투표햤습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateParticipationFailureCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateParticipationFailureCode.java
@@ -1,0 +1,22 @@
+package com.newsnack.www.newsnackserver.common.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DebateParticipationFailureCode implements FailureCode {
+    /**
+     * 404 Not Found
+     */
+    NOT_PARTICIPATED_DEBATE(HttpStatus.NOT_FOUND,"투표를 먼저 하셔야 합니다"),
+    /**
+     * 409 Conflict
+     */
+    ALREADY_COMMENTED_DEBATE(HttpStatus.CONFLICT,"이미 작성한 댓글입니다");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateParticipationFailureCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/failure/DebateParticipationFailureCode.java
@@ -11,6 +11,7 @@ public enum DebateParticipationFailureCode implements FailureCode {
      * 404 Not Found
      */
     NOT_PARTICIPATED_DEBATE(HttpStatus.NOT_FOUND,"투표를 먼저 하셔야 합니다"),
+    NOT_FOUND_DEBATE(HttpStatus.NOT_FOUND, "토론이 없습니다"),
     /**
      * 409 Conflict
      */

--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/success/DebateParticipationSuccessCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/success/DebateParticipationSuccessCode.java
@@ -1,0 +1,17 @@
+package com.newsnack.www.newsnackserver.common.code.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DebateParticipationSuccessCode implements SuccessCode{
+    /**
+     * 200 OK
+     **/
+    DEBATE_PARTICIPATION_SUCCESS(HttpStatus.OK, "토론 댓글 작성 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/common/code/success/DebateSuccessCode.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/code/success/DebateSuccessCode.java
@@ -11,7 +11,11 @@ public enum DebateSuccessCode implements SuccessCode{
     /**
      * 200 OK
      **/
-    GET_DEBATES_SUCCESS(HttpStatus.OK, "토론 조회 성공");
+    GET_DEBATES_SUCCESS(HttpStatus.OK, "토론 조회 성공"),
+    /**
+     * 201 CREATED
+     **/
+    DEBATE_VOTE_SUCCESS(HttpStatus.CREATED, "투표 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/newsnack/www/newsnackserver/common/exception/DebateParticipationException.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/exception/DebateParticipationException.java
@@ -1,0 +1,18 @@
+package com.newsnack.www.newsnackserver.common.exception;
+
+import com.newsnack.www.newsnackserver.common.code.failure.FailureCode;
+import lombok.Getter;
+
+@Getter
+public class DebateParticipationException extends RuntimeException{
+    private final FailureCode failureCode;
+    public DebateParticipationException(FailureCode failureCode) {
+        super("[DebateParticipationException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+
+    public int getHttpStatusCode() {
+        return failureCode.getHttpStatus().value();
+    }
+
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/common/handler/NewSnackControllerAdvice.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/common/handler/NewSnackControllerAdvice.java
@@ -49,6 +49,13 @@ public class NewSnackControllerAdvice {
                 .body(NewSnackResponse.error(e.getFailureCode()));
     }
 
+    @ExceptionHandler(DebateParticipationException.class)
+    public ResponseEntity<NewSnackResponse<?>> handleDebateParticipationException(DebateParticipationException e) {
+        log.info("handleDebateParticipationException() in NewSnackControllerAdvice throw DebateParticipationException : {}", e.getMessage());
+        return ResponseEntity.status(e.getHttpStatusCode())
+                .body(NewSnackResponse.error(e.getFailureCode()));
+    }
+
     @ExceptionHandler(MemberException.class)
     public ResponseEntity<NewSnackResponse<?>> handleMemberException(MemberException e) {
         log.info("handleMemberException() in NewSnackControllerAdvice throw MemberException : {}", e.getMessage());

--- a/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
@@ -3,14 +3,13 @@ package com.newsnack.www.newsnackserver.controller;
 import com.newsnack.www.newsnackserver.annotation.MemberId;
 import com.newsnack.www.newsnackserver.common.code.success.DebateSuccessCode;
 import com.newsnack.www.newsnackserver.common.response.NewSnackResponse;
+import com.newsnack.www.newsnackserver.dto.request.DebateVoteRequest;
 import com.newsnack.www.newsnackserver.dto.response.DebateIndividualResponse;
 import com.newsnack.www.newsnackserver.dto.response.DebateMainPageResponse;
 import com.newsnack.www.newsnackserver.service.DebateService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,5 +33,11 @@ public class DebateController {
     @GetMapping("/{debateId}")
     public NewSnackResponse<DebateIndividualResponse> getDebate(@PathVariable Long debateId, @MemberId(isForSecuredApi = false) Long memberId) {
         return NewSnackResponse.success(DebateSuccessCode.GET_DEBATES_SUCCESS, debateService.getDebate(debateId, memberId));
+    }
+
+    @PostMapping("/{debateId}/votes")
+    public NewSnackResponse<?> voteDebate(@PathVariable Long debateId, @MemberId Long memberId, @RequestBody DebateVoteRequest debateVoteRequest) {
+        debateService.voteDebate(debateId, memberId, debateVoteRequest.vote());
+        return NewSnackResponse.success(DebateSuccessCode.DEBATE_VOTE_SUCCESS);
     }
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
@@ -7,6 +7,7 @@ import com.newsnack.www.newsnackserver.common.response.NewSnackResponse;
 import com.newsnack.www.newsnackserver.controller.parameter.SearchOrder;
 import com.newsnack.www.newsnackserver.dto.request.DebateParticipationRequest;
 import com.newsnack.www.newsnackserver.dto.request.DebateVoteRequest;
+import com.newsnack.www.newsnackserver.dto.response.DebateCommentResponse;
 import com.newsnack.www.newsnackserver.dto.response.DebateIndividualResponse;
 import com.newsnack.www.newsnackserver.dto.response.DebateMainPageResponse;
 import com.newsnack.www.newsnackserver.service.DebateParticipationService;
@@ -51,5 +52,11 @@ public class DebateController {
     public NewSnackResponse<?> createDebateComment(@PathVariable Long debateId, @MemberId Long memberId, @RequestBody @Valid DebateParticipationRequest request) {
         debateParticipationService.participateDebate(debateId, memberId, request.content());
         return NewSnackResponse.success(DebateParticipationSuccessCode.DEBATE_PARTICIPATION_SUCCESS);
+    }
+
+    @GetMapping("/{debateId}/comments")
+    public NewSnackResponse<List<DebateCommentResponse>> getDebateComments(@PathVariable Long debateId, @MemberId(isForSecuredApi = false) Long memberId,
+                                                                           @RequestParam SearchOrder order) {
+        return NewSnackResponse.success(DebateSuccessCode.GET_DEBATES_SUCCESS, debateParticipationService.getDebateComments(debateId, memberId, order));
     }
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
@@ -1,12 +1,17 @@
 package com.newsnack.www.newsnackserver.controller;
 
 import com.newsnack.www.newsnackserver.annotation.MemberId;
+import com.newsnack.www.newsnackserver.common.code.success.DebateParticipationSuccessCode;
 import com.newsnack.www.newsnackserver.common.code.success.DebateSuccessCode;
 import com.newsnack.www.newsnackserver.common.response.NewSnackResponse;
+import com.newsnack.www.newsnackserver.controller.parameter.SearchOrder;
+import com.newsnack.www.newsnackserver.dto.request.DebateParticipationRequest;
 import com.newsnack.www.newsnackserver.dto.request.DebateVoteRequest;
 import com.newsnack.www.newsnackserver.dto.response.DebateIndividualResponse;
 import com.newsnack.www.newsnackserver.dto.response.DebateMainPageResponse;
+import com.newsnack.www.newsnackserver.service.DebateParticipationService;
 import com.newsnack.www.newsnackserver.service.DebateService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +24,7 @@ import java.util.List;
 public class DebateController {
 
     private final DebateService debateService;
+    private final DebateParticipationService debateParticipationService;
 
     @GetMapping
     public NewSnackResponse<List<DebateMainPageResponse>> getDebates() {
@@ -39,5 +45,11 @@ public class DebateController {
     public NewSnackResponse<?> voteDebate(@PathVariable Long debateId, @MemberId Long memberId, @RequestBody DebateVoteRequest debateVoteRequest) {
         debateService.voteDebate(debateId, memberId, debateVoteRequest.vote());
         return NewSnackResponse.success(DebateSuccessCode.DEBATE_VOTE_SUCCESS);
+    }
+
+    @PostMapping("/{debateId}/comments")
+    public NewSnackResponse<?> createDebateComment(@PathVariable Long debateId, @MemberId Long memberId, @RequestBody @Valid DebateParticipationRequest request) {
+        debateParticipationService.participateDebate(debateId, memberId, request.content());
+        return NewSnackResponse.success(DebateParticipationSuccessCode.DEBATE_PARTICIPATION_SUCCESS);
     }
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/controller/DebateController.java
@@ -13,7 +13,6 @@ import com.newsnack.www.newsnackserver.dto.response.DebateMainPageResponse;
 import com.newsnack.www.newsnackserver.service.DebateParticipationService;
 import com.newsnack.www.newsnackserver.service.DebateService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debate/model/Debate.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debate/model/Debate.java
@@ -27,4 +27,12 @@ public class Debate extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
     private Article article;
+
+    public void upVote() {
+        this.upVoteCount++;
+    }
+
+    public void downVote() {
+        this.downVoteCount++;
+    }
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
@@ -1,16 +1,21 @@
 package com.newsnack.www.newsnackserver.domain.debateparticipation.model;
 
+import com.newsnack.www.newsnackserver.domain.commom.BaseTimeEntity;
 import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
+import com.newsnack.www.newsnackserver.domain.debateparticipationheart.model.DebateParticipationHeart;
 import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DebateParticipation {
+public class DebateParticipation extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,9 +29,14 @@ public class DebateParticipation {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "debateParticipation", cascade = CascadeType.ALL, orphanRemoval = true)//둘다 부모 삭제시 자식 모두 삭제, orphanRemoval: debateParticipationHearts.remove만 해도 DB에서 삭제됨
+    private List<DebateParticipationHeart> debateParticipationHearts = new ArrayList<>();
+
     private Boolean vote;
 
     private String comment;
+
+    private int heartCount;
 
     public void updateComment(String comment) {
         this.comment = comment;

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
@@ -28,6 +28,10 @@ public class DebateParticipation {
 
     private String comment;
 
+    public void updateComment(String comment) {
+        this.comment = comment;
+    }
+
     public DebateParticipation(Debate debate, Member member, Boolean vote) {
         this.debate = debate;
         this.member = member;

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/model/DebateParticipation.java
@@ -28,4 +28,10 @@ public class DebateParticipation {
 
     private String comment;
 
+    public DebateParticipation(Debate debate, Member member, Boolean vote) {
+        this.debate = debate;
+        this.member = member;
+        this.vote = vote;
+    }
+
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/repository/DebateParticipationJpaRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/repository/DebateParticipationJpaRepository.java
@@ -1,10 +1,12 @@
 package com.newsnack.www.newsnackserver.domain.debateparticipation.repository;
 
+import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
+import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface DebateParticipationJpaRepository extends JpaRepository<DebateParticipation, Long> {
-    Optional<DebateParticipation> findByDebateIdAndMemberId(Long debateId, Long memberId);
+    Optional<DebateParticipation> findByDebateAndMember(Debate debate, Member member);
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/repository/DebateParticipationJpaRepository.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/domain/debateparticipation/repository/DebateParticipationJpaRepository.java
@@ -4,9 +4,22 @@ import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
 import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DebateParticipationJpaRepository extends JpaRepository<DebateParticipation, Long> {
     Optional<DebateParticipation> findByDebateAndMember(Debate debate, Member member);
+
+    @Query("select dp from DebateParticipation dp join fetch dp.member where dp.debate.id = :debateId order by dp.id desc")
+    List<DebateParticipation> findAllWithMemberByDebateIdOrderByIdDescJPQL(Long debateId);
+
+    @Query("select dp from DebateParticipation dp join fetch dp.member where dp.debate.id = :debateId order by dp.heartCount desc, dp.id desc")
+    List<DebateParticipation> findAllWithMemberByDebateIdOrderByHeartCountDescJPQL(Long debateId);
+
+    @Query("select distinct dp from DebateParticipation dp left join fetch dp.debateParticipationHearts join fetch dp.member where dp.debate.id = :debateId order by dp.id desc")
+    List<DebateParticipation> findAllWithMemberAndDebateParticipationHeartByDebateIdOrderByIdDescJPQL(Long debateId);
+    @Query("select distinct dp from DebateParticipation dp left join fetch dp.debateParticipationHearts join fetch dp.member where dp.debate.id = :debateId order by dp.heartCount desc, dp.id desc")
+    List<DebateParticipation> findAllWithMemberAndDebateParticipationHeartByDebateIdOrderByHeartCountDescJPQL(Long debateId);
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateParticipationRequest.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateParticipationRequest.java
@@ -1,0 +1,7 @@
+package com.newsnack.www.newsnackserver.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record DebateParticipationRequest(@Size(min = 1, max = 200) @NotBlank String content) {
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateVoteRequest.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateVoteRequest.java
@@ -1,7 +1,4 @@
 package com.newsnack.www.newsnackserver.dto.request;
 
-import jakarta.validation.constraints.Max;
-import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
-
 public record DebateVoteRequest(boolean vote) {
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateVoteRequest.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/request/DebateVoteRequest.java
@@ -1,0 +1,7 @@
+package com.newsnack.www.newsnackserver.dto.request;
+
+import jakarta.validation.constraints.Max;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+
+public record DebateVoteRequest(boolean vote) {
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/response/DebateCommentResponse.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/response/DebateCommentResponse.java
@@ -2,8 +2,6 @@ package com.newsnack.www.newsnackserver.dto.response;
 
 import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
 
-import java.time.LocalDateTime;
-
 public record DebateCommentResponse(Long id, String writerName, long memberId, boolean vote, String content, String createdAt, int likeCount, boolean isLikedByMe, boolean isMyComment) {
     public static DebateCommentResponse of(DebateParticipation debateParticipation, boolean isLikedByMe, boolean isMyComment) {
         return new DebateCommentResponse(debateParticipation.getId(), debateParticipation.getMember().getName(), debateParticipation.getMember().getId(),

--- a/src/main/java/com/newsnack/www/newsnackserver/dto/response/DebateCommentResponse.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/dto/response/DebateCommentResponse.java
@@ -1,0 +1,13 @@
+package com.newsnack.www.newsnackserver.dto.response;
+
+import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
+
+import java.time.LocalDateTime;
+
+public record DebateCommentResponse(Long id, String writerName, long memberId, boolean vote, String content, String createdAt, int likeCount, boolean isLikedByMe, boolean isMyComment) {
+    public static DebateCommentResponse of(DebateParticipation debateParticipation, boolean isLikedByMe, boolean isMyComment) {
+        return new DebateCommentResponse(debateParticipation.getId(), debateParticipation.getMember().getName(), debateParticipation.getMember().getId(),
+                debateParticipation.getVote(), debateParticipation.getComment(),
+                debateParticipation.getCreatedAt().toString(), debateParticipation.getHeartCount(), isLikedByMe, isMyComment);
+    }
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/security/config/SecurityConfig.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/security/config/SecurityConfig.java
@@ -17,8 +17,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/src/main/java/com/newsnack/www/newsnackserver/security/config/SecurityConfig.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/security/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                                 .requestMatchers("/v1/articles/{articleId}", "/v1/articles", "/v1/articles/main").permitAll()
                                 .requestMatchers("v1/debates/{debateId}", "/v1/debates", "/v1/debates/main").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/v1/articles/{articleId}/comments").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/v1/debates/{debateId}/comments").permitAll()
                                 .anyRequest().authenticated())//인증 필요
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
@@ -1,0 +1,35 @@
+package com.newsnack.www.newsnackserver.service;
+
+import com.newsnack.www.newsnackserver.common.code.failure.DebateParticipationFailureCode;
+import com.newsnack.www.newsnackserver.common.exception.DebateParticipationException;
+import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
+import com.newsnack.www.newsnackserver.domain.debate.repository.DebateJpaRepository;
+import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
+import com.newsnack.www.newsnackserver.domain.debateparticipation.repository.DebateParticipationJpaRepository;
+import com.newsnack.www.newsnackserver.domain.member.model.Member;
+import com.newsnack.www.newsnackserver.domain.member.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class DebateParticipationService {
+    private final DebateParticipationJpaRepository debateParticipationJpaRepository;
+    private final DebateJpaRepository debateJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
+
+    @Transactional
+    public void participateDebate(Long debateId, Long memberId, String content) {
+        Debate debate = debateJpaRepository.getReferenceById(debateId);
+        Member member = memberJpaRepository.getReferenceById(memberId);
+
+        DebateParticipation debateParticipation = debateParticipationJpaRepository.findByDebateAndMember(debate, member)
+                .orElseThrow(() -> new DebateParticipationException(DebateParticipationFailureCode.NOT_PARTICIPATED_DEBATE));
+        if (debateParticipation.getComment() != null) {
+            throw new DebateParticipationException(DebateParticipationFailureCode.ALREADY_COMMENTED_DEBATE);
+        }
+        debateParticipation.updateComment(content);
+    }
+}

--- a/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
@@ -1,16 +1,27 @@
 package com.newsnack.www.newsnackserver.service;
 
+import com.newsnack.www.newsnackserver.annotation.MemberId;
 import com.newsnack.www.newsnackserver.common.code.failure.DebateParticipationFailureCode;
 import com.newsnack.www.newsnackserver.common.exception.DebateParticipationException;
+import com.newsnack.www.newsnackserver.controller.parameter.SearchOrder;
+import com.newsnack.www.newsnackserver.domain.comment.model.Comment;
 import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
 import com.newsnack.www.newsnackserver.domain.debate.repository.DebateJpaRepository;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.repository.DebateParticipationJpaRepository;
 import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import com.newsnack.www.newsnackserver.domain.member.repository.MemberJpaRepository;
+import com.newsnack.www.newsnackserver.dto.response.CommentResponse;
+import com.newsnack.www.newsnackserver.dto.response.DebateCommentResponse;
+import com.newsnack.www.newsnackserver.dto.response.DebateIndividualResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+import static java.util.Arrays.stream;
 
 @Transactional(readOnly = true)
 @Service
@@ -32,4 +43,32 @@ public class DebateParticipationService {
         }
         debateParticipation.updateComment(content);
     }
+
+    public List<DebateCommentResponse> getDebateComments(Long debateId, Long memberId, SearchOrder searchOrder) {
+        Debate debate = debateJpaRepository.findById(debateId).orElseThrow(() -> new DebateParticipationException(DebateParticipationFailureCode.NOT_FOUND_DEBATE));
+        if(memberId == null) { // 비회원일 경우
+            if (searchOrder.getValue().equals(SearchOrder.RECENT.getValue()))// 최신순 정렬
+                return debateParticipationJpaRepository.findAllWithMemberByDebateIdOrderByIdDescJPQL(debateId)
+                        .stream().map(debateParticipation -> DebateCommentResponse.of(debateParticipation, false, false)).toList();
+            if (searchOrder.getValue().equals(SearchOrder.POPULAR.getValue())) // 인기순 정렬
+                return debateParticipationJpaRepository.findAllWithMemberByDebateIdOrderByHeartCountDescJPQL(debateId)
+                        .stream().map(debateParticipation -> DebateCommentResponse.of(debateParticipation, false, false)).toList();
+        }
+        //회원일 경우 1000 -> boolean 값 4개 변경 해야함
+        if (searchOrder.getValue().equals(SearchOrder.RECENT.getValue())) {// 최신순 정렬
+            return debateParticipationJpaRepository.findAllWithMemberAndDebateParticipationHeartByDebateIdOrderByIdDescJPQL(debateId)
+                    .stream().map(debateParticipation -> DebateCommentResponse.of(debateParticipation, isLikedByMe(debateParticipation, memberId), isMyDebateParticipation(debateParticipation, memberId))).toList();
+        }
+        //인기순
+        return debateParticipationJpaRepository.findAllWithMemberAndDebateParticipationHeartByDebateIdOrderByHeartCountDescJPQL(debateId)
+                .stream().map(debateParticipation -> DebateCommentResponse.of(debateParticipation, isLikedByMe(debateParticipation, memberId), isMyDebateParticipation(debateParticipation, memberId))).toList();
+    }
+    private boolean isLikedByMe(DebateParticipation debateParticipation, Long memberId) {
+        return debateParticipation.getDebateParticipationHearts().stream().anyMatch(commentHeart -> commentHeart.getMember().getId().equals(memberId));
+    }
+
+    private boolean isMyDebateParticipation(DebateParticipation debateParticipation, Long memberId) {
+        return debateParticipation.getMember().getId().equals(memberId);
+    }
+
 }

--- a/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
+++ b/src/main/java/com/newsnack/www/newsnackserver/service/DebateParticipationService.java
@@ -1,27 +1,20 @@
 package com.newsnack.www.newsnackserver.service;
 
-import com.newsnack.www.newsnackserver.annotation.MemberId;
 import com.newsnack.www.newsnackserver.common.code.failure.DebateParticipationFailureCode;
 import com.newsnack.www.newsnackserver.common.exception.DebateParticipationException;
 import com.newsnack.www.newsnackserver.controller.parameter.SearchOrder;
-import com.newsnack.www.newsnackserver.domain.comment.model.Comment;
 import com.newsnack.www.newsnackserver.domain.debate.model.Debate;
 import com.newsnack.www.newsnackserver.domain.debate.repository.DebateJpaRepository;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.model.DebateParticipation;
 import com.newsnack.www.newsnackserver.domain.debateparticipation.repository.DebateParticipationJpaRepository;
 import com.newsnack.www.newsnackserver.domain.member.model.Member;
 import com.newsnack.www.newsnackserver.domain.member.repository.MemberJpaRepository;
-import com.newsnack.www.newsnackserver.dto.response.CommentResponse;
 import com.newsnack.www.newsnackserver.dto.response.DebateCommentResponse;
-import com.newsnack.www.newsnackserver.dto.response.DebateIndividualResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
-
-import static java.util.Arrays.stream;
 
 @Transactional(readOnly = true)
 @Service


### PR DESCRIPTION
## Related Issue 📌
- close #31 

## Description ✔️
- 토론 투표 api 생성
- 토론 댓글 작성 api 생성
- 토론 댓글 보기 api 생성

## To Reviewers
마찬가지로 heartcount를 토론 댓글에 넣어 버려서 나중에 토론 댓글 좋아요 누를 때 갱실분실문제 해결해야함